### PR TITLE
Update GUID to remove EFI_DT_RESERVE_MEMORY and Flags argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,11 @@ Revision History
 | 2025-12-03 | Refer to the Devicetree Specification concerning                |
 |            | memory types for memory reservations.                           |
 +------------+-----------------------------------------------------------------+
+| 2026-01-05 | Release protocol under a new GUID to incorporate the following  |
+|            | breaking changes:                                               |
+|            |   * Remove EFI_DT_RESERVE_MEMORY due to its unsafe nature.      |
+|            |   * Remove the flags argument as it is no longer used.          |
++------------+-----------------------------------------------------------------+
 
 License
 -------
@@ -72,10 +77,8 @@ Summary
 ~~~~~~~
 
 The EFI device-tree fix-up protocol provides a function to let the firmware
-apply fix-ups.
-
-Furthermore the function can be used to adjust the UEFI memory map according
-to the reservations defined in the device-tree.
+apply fix-ups to a device-tree to ensure it aligns with the firmware's specific
+view of the platform.
 
 GUID
 ~~~~
@@ -83,8 +86,8 @@ GUID
 .. code-block:: c
 
     #define EFI_DT_FIXUP_PROTOCOL_GUID \
-     { 0xe617d64c, 0xfe08, 0x46da, \
-     { 0xf4, 0xdc, 0xbb, 0xd5, 0x87, 0x0c, 0x73, 0x00 } }
+     { 0x60ed6ba9, 0xdfef, 0x4799, \
+     { 0xac, 0x7b, 0x75, 0xe0, 0xf8, 0x33, 0x45, 0x6c } }
 
 Revision Number
 ~~~~~~~~~~~~~~~
@@ -113,7 +116,7 @@ Revision
     compatibility, a new GUID must be defined.
 
 Fixup
-    Applies fix-ups to a device-tree and makes memory reservations.
+    Applies fix-ups to a device-tree.
 
 EFI_DT_FIXUP_PROTOCOL.Fixup()
 -----------------------------
@@ -121,7 +124,7 @@ EFI_DT_FIXUP_PROTOCOL.Fixup()
 Summary
 ~~~~~~~
 
-Applies fix-ups to a device-tree and makes memory reservations.
+Applies fix-ups to a device-tree.
 
 Prototype
 ~~~~~~~~~
@@ -131,9 +134,8 @@ Prototype
     typedef EFI_STATUS
     (EFIAPI *EFI_DT_FIXUP) (
         IN EFI_DT_FIXUP_PROTOCOL *This,
-        IN VOID                  *Fdt,
-        IN OUT UINTN             *BufferSize,
-        IN UINT32                Flags
+        IN OUT VOID              *Fdt,
+        IN OUT UINTN             *BufferSize
         );
 
 Parameters
@@ -150,40 +152,11 @@ BufferSize
     fix-ups. If the buffer size is too small, the required buffer size is
     returned.
 
-Flags
-    Bitmap containing at least one of the values
-
-    * **EFI_DT_APPLY_FIXUPS**
-    * **EFI_DT_RESERVE_MEMORY**
-
-    Indicates the actions to be applied to the device-tree.
-
-Related Definitions
-~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: c
-
-    /* Add nodes and update properties */
-    #define EFI_DT_APPLY_FIXUPS    0x00000001
-    /*
-     * Reserve memory according to the /reserved-memory node
-     * and the memory reservation block
-     */
-    #define EFI_DT_RESERVE_MEMORY  0x00000002
-
 Description
 ~~~~~~~~~~~
 
 The **Fixup()** function is called by a UEFI binary that has loaded a
-device-tree to let the firmware apply firmware specific fix-ups and adjust
-memory reservations.
-
-Which of these actions shall be executed is determined by the *Flags* parameter.
-The selected actions indicated in *Flags* are applied in the sequence:
-
-* Add nodes and update properties.
-* Reserve memory according to the /reserved-memory node and the memory
-  reservation block
+device-tree to let the firmware apply firmware specific fix-ups.
 
 The extent to which the validity of the device-tree is checked is
 implementation-dependent. But a buffer without the correct value of the *magic*
@@ -192,42 +165,23 @@ field of the flattened device-tree header must be rejected with
 
 The buffer size must at least equal the *totalsize* field of the device tree.
 
-The required buffer size when called with **EFI_DT_APPLY_FIXUPS** should enforce
-at least 4 KiB unused space for additional fix-ups by the operating system or
-the caller. The available space in the device-tree shall be determined using the
-device-tree header fields::
+The required buffer size should enforce at least 4 KiB unused space for
+additional fix-ups by the operating system or the caller. The available space in
+the device-tree shall be determined using the device-tree header fields::
 
     available = header->totalsize
               - header->off_dt_strings
               - header->size_dt_strings
 
-(The strings block is always last in the flattened device-tree. There
-might be more space between blocks but not all device-tree libraries can
-use it.)
+(The strings block is always last in the flattened device-tree. There might be
+more space between blocks but not all device-tree libraries can use it.)
 
-If the buffer is too small, **EFI_BUFFER_TOO_SMALL** is returned,
-the device-tree is unmodified and the value pointed to by *BufferSize* is
-updated with the required buffer size for the provided device-tree.
+If the buffer is too small, **EFI_BUFFER_TOO_SMALL** is returned, the
+device-tree is unmodified and the value pointed to by *BufferSize* is updated
+with the required buffer size for the provided device-tree.
 
-If any other error code is returned in response to a call with
-**EFI_DT_APPLY_FIXUPS**, the state of the device-tree is undefined. The caller
-should discard the buffer content.
-
-When **Fixup()** is called with **EFI_DT_RESERVE_MEMORY**, memory is reserved
-according to the /reserved-memory node and the memory reservation block
-
-The `Devicetree Specification <https://www.devicetree.org/specifications/>`_
-defines the EFI memory types to be used for reserved memory.
-
-Here is a non-authoritative summary of the memory type requirements
-according to the Devicetree Specification v0.4 released 2024-06-28:
-
-- Memory regions listed in the memory reservation block are marked as
-  **EfiReservedMemoryType**.
-
-- Memory regions in the /reserved-memory node are marked as
-  **EfiReservedMemoryType** if they possess the **no-map** property and as
-  **EfiBootServicesData** otherwise.
+If any other error code is returned the state of the device-tree is undefined.
+The caller should discard the buffer content.
 
 Status Codes Returned
 ~~~~~~~~~~~~~~~~~~~~~
@@ -240,8 +194,6 @@ Status Codes Returned
 +---------------------------+-------------------------------------------------+
 | **EFI_INVALID_PARAMETER** | *Fdt* does not point to a valid device-tree     |
 |                           | (e.g. incorrect value of magic)                 |
-+---------------------------+-------------------------------------------------+
-| **EFI_INVALID_PARAMETER** | Invalid value of *Flags* (zero or unknown bit)  |
 +---------------------------+-------------------------------------------------+
 | **EFI_BUFFER_TOO_SMALL**  | The buffer is too small to apply the fix-ups.   |
 +---------------------------+-------------------------------------------------+


### PR DESCRIPTION
Due to [feedback](https://github.com/tianocore/edk2/pull/11667#pullrequestreview-3398372185) from EDK2 maintainers, `EFI_DT_FIXUP_PROTOCOL` cannot be upstreamed into EDK2 or the UEFI spec as-is.

Following the proposals doing the following:

1. Remove `EFI_DT_RESERVE_MEMORY`, as it is unrelated to DT fix-ups and unreliable in its current state.
2. Remove the `flag` argument, since `EFI_DT_RESERVE_MEMORY` was the last one.
3. Use a new GUID, as these modifications constitute a breaking change.